### PR TITLE
Added callable customHeading

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -22,5 +22,8 @@
 // $enableFortune = false;
 // $fortunePath = "/usr/games/fortune";
 
-// Uncomment to show custom heading
+// Set to callable to write custom heading by function
+// $nagliteHeading = function() { echo("<h2>This is Naglite3</h2>\n"); };
+// Set to string to write the string
 // $nagliteHeading = '<Your Custom Heading>';
+//

--- a/index.php
+++ b/index.php
@@ -363,7 +363,9 @@ echo "<!--\n";
 // var_dump($hostInfo);
 echo "-->\n";
 echo '<div id="content">';
-if($nagliteHeading) {
+if(is_callable($nagliteHeading)) {
+	$nagliteHeading(); 
+} elseif ($nagliteHeading) {
     echo '<h1>'.$nagliteHeading.'</h1>';
 }
 


### PR DESCRIPTION
At customer site, we needed to show customizable heading based on external dependencies (e.g. display operator on duty). The easiest way was to define customHeading  as function which performs database lookup.

The patch is attached in this Pull request.
