### PR TITLE
Allow per site css

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,6 +44,9 @@ For all possible config options have a look at config.php.example
 If you want to change colors, create a file called 'custom.css' in the
 directory where Naglite3 is placed and add your changes.
 
+If you want to use a per site css, just pass the GET-parameter "css" pointing to a local file.
+e.g. http://your-host/Naglite3/?css=my_custom_css
+
 ### Refresh interval
 
 You can change the refresh interval (in seconds) through a GET parameter, too.

--- a/index.php
+++ b/index.php
@@ -369,6 +369,9 @@ echo "	<link rel=\"stylesheet\" type=\"text/css\" media=\"screen\" href=\"defaul
 if (is_readable("custom.css")) {
 	echo "	<link rel=\"stylesheet\" type=\"text/css\" media=\"screen\" href=\"custom.css\" />\n";
 }
+if (isset($_GET['css']) && is_readable(basename($_GET['css']) . '.css')) {
+	echo "	<link rel=\"stylesheet\" type=\"text/css\" media=\"screen\" href=\"".basename($_GET['css']).".css\" />\n";
+}
 echo "</head>\n";
 echo "<body>\n";
 echo "<!--\n";


### PR DESCRIPTION
In the case that someone wants to use the same Naglite installation on different screens, they should be able to pass a custom css file.